### PR TITLE
revenueShare 계산값 변경

### DIFF
--- a/contracts/components/model/ISpinProtocol.sol
+++ b/contracts/components/model/ISpinProtocol.sol
@@ -62,8 +62,7 @@ interface ISpinProtocol {
   function revenueShare(
     uint256 _revenueLedgerId,
     address _to,
-    uint256 _revenue,
-    uint256 _spinRatio,
+    uint256 _spinAmount,
     uint256 _marketPrice,
     uint256 _rounding
   ) external;

--- a/contracts/components/model/RevenueShare.sol
+++ b/contracts/components/model/RevenueShare.sol
@@ -27,30 +27,28 @@ contract RevenueShare is Proxied {
     function rounding(uint256 _value, uint256 _num) public pure returns(uint256){
         return _value / (10 ** _num) * (10 ** _num);
     }
-    
+
     /**
     * @dev Calculates revenue.
     * @param _marketPrice : The value of this parameter must be (_marketPrice * 100) to resolve the decimal point issue.
     */
     function revenueSpin(
-        uint256 _revenue,
-        uint256 _spinRatio,
+        uint256 _spinAmount,
         uint256 _marketPrice,
         uint256 _rounding
     ) public pure returns(uint256 spin){
-        spin = _revenue.mul(1 ether);
-        spin = spin.mul(_spinRatio).div(_marketPrice);
+        spin = _spinAmount.mul(1 ether).mul(100);
+        spin = spin.div(_marketPrice);
         spin = rounding(spin, uint256(18).sub(_rounding));
     }
-    
+
     /**
     * @dev Token transfer after calculates.
     */
     function revenueShare(
         uint256 _revenueLedgerId,
         address _to,
-        uint256 _revenue,
-        uint256 _spinRatio,
+        uint256 _spinAmount,
         uint256 _marketPrice,
         uint256 _rounding
     ) external onlyProxy {
@@ -59,7 +57,7 @@ contract RevenueShare is Proxied {
         (campaignId,,,,,,,,isAccount) = ISpinProtocol(proxy.getContract(CONTRACT_NAME_REVENUE_LEDGER_DB)).getRevenueLedger(_revenueLedgerId);
         require(campaignId > 0 && !isAccount, "Empty data or already share");
 
-        uint256 spin = revenueSpin(_revenue, _spinRatio, _marketPrice, _rounding);
+        uint256 spin = revenueSpin(_spinAmount, _marketPrice, _rounding);
         _sendToken(_to, spin);
         ISpinProtocol(proxy.getContract(CONTRACT_NAME_REVENUE_LEDGER_DB)).updateIsAccount(_revenueLedgerId,true);
     }

--- a/contracts/components/system/SpinProtocolProxy.sol
+++ b/contracts/components/system/SpinProtocolProxy.sol
@@ -137,8 +137,7 @@ contract SpinProtocolProxy is ProxyBase {
   function revenueShare(
     uint256 _revenueLedgerId,
     address _to,
-    uint256 _revenue,
-    uint256 _spinRatio,
+    uint256 _spinAmount,
     uint256 _marketPrice,
     uint256 _rounding
   ) 
@@ -147,8 +146,7 @@ contract SpinProtocolProxy is ProxyBase {
     ISpinProtocol(addressOfSpinProtocol()).revenueShare(
       _revenueLedgerId,
       _to,
-      _revenue,
-      _spinRatio,
+      _spinAmount,
       _marketPrice,
       _rounding
     );

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,4 +1,4 @@
-const PrivateKeyConnector = require('connect-privkey-to-provider');
+const PrivateKeyConnector = require('truffle-hdwallet-provider-klaytn');
 const credentials = require('./credentials.json');
 const { go } = require('ffp-js');
 


### PR DESCRIPTION
Mason 요청
넘기는 값을 총 수익이 아닌 총 수익을 스핀 비율로 나누고 세금공제가 된 값 넘김 